### PR TITLE
Remove bottle :unneeded directive to silence brew warning

### DIFF
--- a/depscloud-cli.rb
+++ b/depscloud-cli.rb
@@ -6,7 +6,6 @@ class DepscloudCli < Formula
   desc "Command line interface to the deps.cloud API"
   homepage "https://deps.cloud/"
   version "0.3.5"
-  bottle :unneeded
 
   on_macos do
     if Hardware::CPU.intel?

--- a/depscloud-cli@0.2.x.rb
+++ b/depscloud-cli@0.2.x.rb
@@ -7,7 +7,6 @@ class DepscloudCliAT02X < Formula
   desc "Command line interface to the deps.cloud API"
   homepage "https://deps.cloud/"
   version "0.2.34"
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/depscloud/depscloud/releases/download/v0.2.34/deps_0.2.34_darwin_amd64.tar.gz"


### PR DESCRIPTION
homebrew has been outputting a warning saying that calling `bottle :unneeded` is deprecated and there is no replacement. This pull request addresses the warning by removing the concerned lines.

### References
As per this discussion it should be fine to just remove the line: https://github.com/Homebrew/discussions/discussions/2311#discussioncomment-1507233

Some other projects' fix for the same issue:
https://github.com/derailed/homebrew-k9s/pull/4
https://github.com/minamijoyo/homebrew-tfschema/commit/bc61cd182cd921da608692e199e2f6bec57382f9
https://github.com/goreleaser/goreleaser/pull/2591
https://github.com/hashicorp/homebrew-tap/pull/157

